### PR TITLE
Add useKeyEventListener

### DIFF
--- a/src/ExpoKeyEventModule.ts
+++ b/src/ExpoKeyEventModule.ts
@@ -7,7 +7,7 @@ declare class ExpoKeyEventModule extends NativeModule<ExpoKeyEventModuleEvents> 
   stopListening(): void;
 }
 
-let Module;
+let Module: ReturnType<typeof requireNativeModule<ExpoKeyEventModule>>;
 try {
   Module = requireNativeModule<ExpoKeyEventModule>("ExpoKeyEvent");
 } catch (e) {

--- a/src/hooks/useKeyEventListener.ts
+++ b/src/hooks/useKeyEventListener.ts
@@ -1,0 +1,43 @@
+import {useEventListener} from 'expo';
+import {useCallback, useEffect} from 'react';
+
+import {KeyPressEvent} from '../ExpoKeyEvent.types';
+import ExpoKeyEventModule from '../ExpoKeyEventModule';
+import {unifyKeyCode} from '../utils/unifyKeyCode';
+
+/**
+ *
+ * @param listenOnMount Pass 'false' to prevent automatic key event listening
+ * - Use startListening/stopListening to control the listener manually
+ *
+ */
+export function useKeyEventListener(
+  listener: (event: KeyPressEvent) => void,
+  listenOnMount = true
+) {
+  const onKeyPress = useCallback(
+    ({key}: KeyPressEvent) => listener({key: unifyKeyCode(key)}),
+    [listener]
+  );
+
+  useEventListener(ExpoKeyEventModule, 'onKeyPress', onKeyPress);
+
+  useEffect(() => {
+    if (listenOnMount) ExpoKeyEventModule.startListening();
+
+    return () => {
+      ExpoKeyEventModule.stopListening();
+    };
+  }, [listenOnMount]);
+
+  return {
+    /**
+     * Start listening for key events
+     */
+    startListening: () => ExpoKeyEventModule.startListening(),
+    /**
+     * Stop listening for key events
+     */
+    stopListening: () => ExpoKeyEventModule.stopListening(),
+  };
+}

--- a/src/hooks/useKeyEventListener.web.ts
+++ b/src/hooks/useKeyEventListener.web.ts
@@ -1,0 +1,40 @@
+import {useCallback, useEffect} from 'react';
+
+import {KeyPressEvent} from '../ExpoKeyEvent.types';
+import ExpoKeyEventModule from '../ExpoKeyEventModule';
+
+/**
+ *
+ * @param listenOnMount Pass 'false' to prevent automatic key event listening
+ * - Use startListening/stopListening to control the listener manually
+ * @returns
+ *
+ */
+export function useKeyEventListener(
+  listener: (event: KeyPressEvent) => void,
+  listenOnMount = true
+) {
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent) => listener({key: event.code}),
+    [listener]
+  );
+
+  useEffect(() => {
+    if (listenOnMount) addEventListener('keydown', onKeyDown);
+
+    return () => {
+      removeEventListener('keydown', onKeyDown);
+    };
+  }, [listenOnMount]);
+
+  return {
+    /**
+     * Start listening for key events
+     */
+    startListening: () => ExpoKeyEventModule.startListening(),
+    /**
+     * Stop listening for key events
+     */
+    stopListening: () => ExpoKeyEventModule.stopListening(),
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export { useKeyEvent } from "./hooks/useKeyEvent";
+export {useKeyEvent} from './hooks/useKeyEvent';
+export {useKeyEventListener} from './hooks/useKeyEventListener';


### PR DESCRIPTION
Introduce new `useKeyEventListener` hook which can provide better performance if needed.

With `useKeyEvent` (`useEvent`) it causes render on every key even. When using that with barcode scanners it resulted in performance issues (only tested Android so far) and events got lost. `useKeyEventListener.web.ts` is untested.

# Other changes

- Fix (internal) exported type of native module from `ExpoKeyEventModule.ts` - it was `any` before.