### PR TITLE
Return stable startListening/stopListening callbacks

### DIFF
--- a/src/hooks/useKeyEvent.ts
+++ b/src/hooks/useKeyEvent.ts
@@ -37,11 +37,11 @@ export function useKeyEvent(listenOnMount = true, preventReload = false) {
     /**
      * Start listening for key events
      */
-    startListening: () => ExpoKeyEventModule.startListening(),
+    startListening: ExpoKeyEventModule.startListening,
     /**
      * Stop listening for key events
      */
-    stopListening: () => ExpoKeyEventModule.stopListening(),
+    stopListening: ExpoKeyEventModule.stopListening,
     keyEvent,
   };
 }

--- a/src/hooks/useKeyEvent.web.ts
+++ b/src/hooks/useKeyEvent.web.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+
 import { KeyPressEvent } from "../ExpoKeyEvent.types";
 
 /**
@@ -15,23 +16,32 @@ export function useKeyEvent(listenOnMount = true) {
     setKeyEvent({ key: event.code });
   }, []);
 
-  useEffect(() => {
-    if (listenOnMount) addEventListener("keydown", onKeyDown);
+  const startListening = useCallback(
+    () => addEventListener("keydown", onKeyDown),
+    [onKeyDown],
+  );
 
+  const stopListening = useCallback(
+    () => removeEventListener("keydown", onKeyDown),
+    [onKeyDown],
+  );
+
+  useEffect(() => {
+    if (listenOnMount) startListening();
     return () => {
-      removeEventListener("keydown", onKeyDown);
+      stopListening();
     };
-  }, [listenOnMount]);
+  }, [listenOnMount, startListening, stopListening]);
 
   return {
     /**
      * Start listening for key events
      */
-    startListening: () => addEventListener("keydown", onKeyDown),
+    startListening,
     /**
      * Stop listening for key events
      */
-    stopListening: () => removeEventListener("keydown", onKeyDown),
+    stopListening,
     keyEvent,
   };
 }

--- a/src/hooks/useKeyEventListener.ts
+++ b/src/hooks/useKeyEventListener.ts
@@ -17,7 +17,7 @@ import { unifyKeyCode } from "../utils/unifyKeyCode";
 export function useKeyEventListener(
   listener: (event: KeyPressEvent) => void,
   listenOnMount = true,
-  preventReload = false
+  preventReload = false,
 ) {
   const onKeyPress = useCallback(
     ({ key }: KeyPressEvent) => {
@@ -26,7 +26,7 @@ export function useKeyEventListener(
 
       listener({ key: uniKey });
     },
-    [listener]
+    [listener],
   );
 
   useEventListener(ExpoKeyEventModule, "onKeyPress", onKeyPress);
@@ -43,10 +43,10 @@ export function useKeyEventListener(
     /**
      * Start listening for key events
      */
-    startListening: () => ExpoKeyEventModule.startListening(),
+    startListening: ExpoKeyEventModule.startListening,
     /**
      * Stop listening for key events
      */
-    stopListening: () => ExpoKeyEventModule.stopListening(),
+    stopListening: ExpoKeyEventModule.stopListening,
   };
 }

--- a/src/hooks/useKeyEventListener.web.ts
+++ b/src/hooks/useKeyEventListener.web.ts
@@ -11,29 +11,39 @@ import { KeyPressEvent } from "../ExpoKeyEvent.types";
  */
 export function useKeyEventListener(
   listener: (event: KeyPressEvent) => void,
-  listenOnMount = true
+  listenOnMount = true,
 ) {
   const onKeyDown = useCallback(
     (event: KeyboardEvent) => listener({ key: event.code }),
-    [listener]
+    [listener],
+  );
+
+  const startListening = useCallback(
+    () => addEventListener("keydown", onKeyDown),
+    [onKeyDown],
+  );
+
+  const stopListening = useCallback(
+    () => removeEventListener("keydown", onKeyDown),
+    [onKeyDown],
   );
 
   useEffect(() => {
-    if (listenOnMount) addEventListener("keydown", onKeyDown);
+    if (listenOnMount) startListening();
 
     return () => {
-      removeEventListener("keydown", onKeyDown);
+      stopListening();
     };
-  }, [listenOnMount]);
+  }, [listenOnMount, startListening, stopListening]);
 
   return {
     /**
      * Start listening for key events
      */
-    startListening: () => addEventListener("keydown", onKeyDown),
+    startListening,
     /**
      * Stop listening for key events
      */
-    stopListening: () => removeEventListener("keydown", onKeyDown),
+    stopListening,
   };
 }


### PR DESCRIPTION
Always return the same startListening / stopListening callbacks to avoid needless effects for consumers.